### PR TITLE
Added a script loader HOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Or if you're still using npm:
 npm install --save opentok-react
 ```
 
+Alternatively, wrap your top-level component using OpenTok with the [`preloadScript`](#preloadscript-higher-order-component) HOC. The HOC will take care of loading `opentok.js` for you before rendering. 
+
 ## Example App
 
 There is an example application provided in `example/` and you can run it with the following steps:
@@ -154,6 +156,7 @@ The `opentok-react` library is comprised of:
 - `OTStreams` Component
 - `OTSubscriber` Component
 - `createSession` Helper
+- `preloadScript` Higher-Order Component
 
 ### OTSession Component
 
@@ -277,6 +280,39 @@ The `createSession` helper returns an object with the following properties:
 - `disconnect` - A clean up function. Call this when your component unmounts.
 
 Use of this helper is optional and you can instead use the `OTSession` component or directly call [OT.initSession](https://tokbox.com/developer/sdks/js/reference/OT.html#initSession) and listen to [streamCreated](https://tokbox.com/developer/sdks/js/reference/Session.html#event:streamCreated) events if you prefer.
+
+
+### `preloadScript` Higher-Order Component
+In larger applications, one might not want to load the `opentok.js` client with a `<script>` tag all the time. The `preloadScript` higher-order component will do this for you at the appropriate time.
+
+For example, imagine you have a React Router application with the following route structure:
+
+```javascript
+<Router>
+  <Route path="/">
+    <IndexRoute component="..." />
+    <Route path="something" component="..." />
+    <Route path="video" component={VideoChat} />
+    <Route path="something-else" component="..." />
+  </Route>
+</Router>
+```
+
+What you'd like to do is delay the loading of `opentok.js` until the `VideoChat` component is being used. Here's how you can do this:
+
+```javascript
+class VideoChat extends React.Component {
+  // All the code of your component
+}
+
+export default preloadScript(App);
+```
+
+When rendering the `preloadScript` HOC, it accepts two optional props:
+
+  * `opentokClientUrl`: The URL of the OpenTok client script to load. It defaults to `https://static.opentok.com/v2/js/opentok.min.js`.
+  * `loadingDelegate`: An element that will be displayed while the OpenTok client script is loading. It defaults to an empty `<div />`.
+
 
 ## Custom Build
 

--- a/example/app.js
+++ b/example/app.js
@@ -4,11 +4,12 @@ import ReactDOM from 'react-dom';
 import config from './config';
 import App from './components/App';
 
-OT.registerScreenSharingExtension('chrome', config.CHROME_EXTENSION_ID, 2);
 ReactDOM.render((
   <App
     apiKey={config.API_KEY}
     sessionId={config.SESSION_ID}
     token={config.TOKEN}
+    loadingDelegate={<div>Loading...</div>}
+    opentokClientUrl="https://static.opentok.com/v2/js/opentok.min.js"
   />
 ), document.getElementById('content'));

--- a/example/components/App.js
+++ b/example/components/App.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 
-import { OTSession, OTStreams } from '../../src'
+import { OTSession, OTStreams, preloadScript } from '../../src'
 import ConnectionStatus from './ConnectionStatus';
 import Publisher from './Publisher';
 import Subscriber from './Subscriber';
+import config from '../config';
 
-export default class App extends Component {
+class App extends Component {
   constructor(props) {
     super(props);
 
@@ -21,6 +22,10 @@ export default class App extends Component {
         this.setState({ connected: false });
       }
     };
+  }
+
+  componentWillMount() {
+    OT.registerScreenSharingExtension('chrome', config.CHROME_EXTENSION_ID, 2);
   }
 
   render() {
@@ -40,3 +45,5 @@ export default class App extends Component {
     );
   }
 }
+
+export default preloadScript(App);

--- a/example/index.html
+++ b/example/index.html
@@ -7,7 +7,6 @@
   <body>
     <div id="content"></div>
 
-    <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
     <script src="bundle.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "opentok-test-scripts": "^3.2.1",
     "react": "^15.1.0",
-    "react-dom": "^15.1.0"
+    "react-display-name": "^0.2.0",
+    "react-dom": "^15.1.0",
+    "scriptjs": "^2.5.8"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,15 @@ import OTPublisher from './OTPublisher';
 import OTStreams from './OTStreams';
 import OTSubscriber from './OTSubscriber';
 import createSession from './createSession';
+import preloadScript from './preloadScript';
 
 export default {
   OTSession,
   OTPublisher,
   OTStreams,
   OTSubscriber,
-  createSession
+  createSession,
+  preloadScript
 };
 
 export {
@@ -17,5 +19,6 @@ export {
   OTPublisher,
   OTStreams,
   OTSubscriber,
-  createSession
+  createSession,
+  preloadScript
 };

--- a/src/preloadScript.js
+++ b/src/preloadScript.js
@@ -1,0 +1,69 @@
+import React, {Component, PropTypes} from 'react';
+import getDisplayName from 'react-display-name';
+import scriptjs from 'scriptjs';
+
+const DEFAULT_SCRIPT_URL = 'https://static.opentok.com/v2/js/opentok.min.js';
+
+/*
+This higher-order component will load the OpenTok client thru a script tag.
+It will render its inner component only when the OpenTok client has loaded.
+In the meantime, it will render a loading element chosen by the developer.
+*/
+export default function preloadScript(InnerComponent) {
+  class PreloadScript extends Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        scriptLoaded: typeof OT !== 'undefined'
+      };
+      this.isPresent = false;
+    }
+
+    componentDidMount() {
+      this.isPresent = true;
+
+      if (this.state.scriptLoaded || this.state.scriptLoading) {
+        return;
+      }
+
+      this.setState({
+        scriptLoading: true
+      });
+
+      const scriptUrl = this.props.opentokClientUrl || DEFAULT_SCRIPT_URL;
+      scriptjs(scriptUrl, this.onScriptLoad);
+    }
+
+    componentWillUnmount() {
+      this.isPresent = false;
+    }
+
+    onScriptLoad = () => {
+      if (this.isPresent) {
+        this.setState({
+          scriptLoaded: true
+        });
+      }
+    }
+
+    render() {
+      const { opentokClientUrl, loadingDelegate, ...restProps } = this.props;
+
+      if (this.state.scriptLoaded) {
+        return <InnerComponent {...restProps} />;
+      }
+      else {
+        return loadingDelegate || <div />;
+      }
+    }
+  };
+
+  PreloadScript.displayName = `preloadScript(${getDisplayName(InnerComponent)})`;
+  PreloadScript.propTypes = {
+    opentokClientUrl: PropTypes.string,
+    loadingDelegate: PropTypes.node
+  };
+
+  return PreloadScript;
+}

--- a/test/preloadScript.spec.js
+++ b/test/preloadScript.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import preloadScript from '../src/preloadScript.js';
+
+describe('preloadScript', () => {
+
+  it('Should render loadingDelegate when OT is not available', () => {
+    const __oldOT = global.OT;
+    global.OT = undefined;
+
+    const OTModule = preloadScript(() => <div className="opentok-module" />);
+    const wrapper = mount(
+      <OTModule loadingDelegate={<div className="loading-delegate" />} />
+    );
+
+    const divContainer = wrapper.render().find('div.loading-delegate');
+    expect(divContainer.length).toBe(1);
+
+    global.OT = __oldOT;
+  });
+
+  it('Should render its inner component when OT is available', () => {
+    const __oldOT = global.OT;
+    global.OT = {};
+
+    const OTModule = preloadScript(() => <div className="opentok-module" />);
+    const wrapper = mount(
+      <OTModule loadingDelegate={<div className="loading-delegate" />} />
+    );
+
+    const divContainer = wrapper.render().find('div.opentok-module');
+    expect(divContainer.length).toBe(1);
+
+    global.OT = __oldOT;
+  });
+});


### PR DESCRIPTION
In larger applications, one might want to only load the OpenTok client when necessary.

This change adds a `preloadScript` higher-order component. This component will delay the
rendering of its inner component until the OpenTok client library has been loaded. It will
then proceed to load the library with `scriptjs`.

This PR also modifies the example to show it working with the HOC.