### PR TITLE
Error handlers

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -29,7 +29,13 @@ export default class OTPublisher extends Component {
     let container = document.createElement('div');
     findDOMNode(this).appendChild(container);
 
-    let publisher = OT.initPublisher(container, this.props.properties);
+    const cb = (err) => {
+      if (err && this.props.onPublisherInitError) {
+        this.props.onPublisherInitError(err);
+      }
+    };
+
+    let publisher = OT.initPublisher(container, this.props.properties, cb);
     publisher.on('streamCreated', this.streamCreatedHandler);
 
     if (
@@ -75,6 +81,10 @@ export default class OTPublisher extends Component {
   publishToSession(publisher) {
     this.props.session.publish(publisher, err => {
       if (err) {
+        if (this.props.onPublishError) {
+          this.props.onPublishError(err);
+        }
+        
         console.error('Failed to publish to OpenTok session:', err);
       }
     });
@@ -137,7 +147,9 @@ export default class OTPublisher extends Component {
 OTPublisher.propTypes = {
   session: PropTypes.object,
   properties: PropTypes.object,
-  eventHandlers: PropTypes.objectOf(PropTypes.func)
+  eventHandlers: PropTypes.objectOf(PropTypes.func),
+  onPublisherInitError: PropTypes.func,
+  onPublishError: PropTypes.func
 };
 
 OTPublisher.defaultProps = {

--- a/src/createSession.js
+++ b/src/createSession.js
@@ -1,5 +1,6 @@
 export default function createSession({
-  apiKey, sessionId, token, onStreamsUpdated
+  apiKey, sessionId, token, onStreamsUpdated,
+  onSessionConnectError
 }) {
   let streams = [];
 
@@ -26,7 +27,11 @@ export default function createSession({
 
   let session = OT.initSession(apiKey, sessionId);
   session.on(eventHandlers);
-  session.connect(token);
+  session.connect(token, (err) => {
+    if (err && onSessionConnectError) {
+      onSessionConnectError(err);
+    }
+  });
 
   return {
     session,


### PR DESCRIPTION
+ Added the `onPublisherInitError` and `onPublishError` as props
for <OTPublisher/>. These wil be triggered when the publisher
fails to initiate and when the publisher fails to publish
repectively

+ Added the `onSessionConnectError` property for the `createSession`
helper. Will be triggered is `session.connect` fails


@aiham - as we discussed in #7, this is just from the top of my mind. Let me know what you think and if that is the direction in which you were thinking!