### PR TITLE
resize video, div styling and send stream on events

### DIFF
--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -39,6 +39,13 @@ export default class OTPublisher extends Component {
       return;
     }
 
+    // manage height and width properties evolution
+    if (this.props.properties.width && this.props.properties.height) {
+      const container = document.getElementById(this.containerId);
+      container.style.width = this.props.properties.width;
+      container.style.height = this.props.properties.height;
+    }
+
     updatePublisherProperty('publishAudio', true);
     updatePublisherProperty('publishVideo', true);
 
@@ -94,7 +101,7 @@ export default class OTPublisher extends Component {
       if (err) {
         this.errorHandler(err);
       } else if (typeof this.props.onPublish === 'function') {
-        this.props.onPublish();
+        this.props.onPublish(publisher.stream);
       }
     });
   }
@@ -108,9 +115,13 @@ export default class OTPublisher extends Component {
     const properties = this.props.properties || {};
     let container;
 
+    this.containerId = uuid();
+    const { containerId } = this;
+
     if (properties.insertDefaultUI !== false) {
       container = document.createElement('div');
       container.setAttribute('class', 'OTPublisherContainer');
+      container.setAttribute('id', containerId);
       this.node.appendChild(container);
     }
 
@@ -167,7 +178,7 @@ export default class OTPublisher extends Component {
   }
 
   render() {
-    return <div ref={node => (this.node = node)} />;
+    return <div style={this.props.style} ref={node => (this.node = node)} />;
   }
 }
 
@@ -186,6 +197,7 @@ OTPublisher.propTypes = {
   onInit: PropTypes.func,
   onPublish: PropTypes.func,
   onError: PropTypes.func,
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 OTPublisher.defaultProps = {
@@ -195,4 +207,5 @@ OTPublisher.defaultProps = {
   onInit: null,
   onPublish: null,
   onError: null,
+  style: {},
 };

--- a/src/OTStreams.js
+++ b/src/OTStreams.js
@@ -9,17 +9,18 @@ export default function OTStreams(props) {
   const child = Children.only(props.children);
 
   const childrenWithProps = Array.isArray(props.streams) ? props.streams.map(
-    stream => (child ? cloneElement(
+    (stream, i) => (child ? cloneElement(
       child,
       {
         session: props.session,
         stream,
+        containerStyle: props.subContainerStyles.length > i ? props.subContainerStyles[i] : {},
         key: stream.id,
       },
     ) : child),
   ) : null;
 
-  return <div>{childrenWithProps}</div>;
+  return <div style={props.style}>{childrenWithProps}</div>;
 }
 
 OTStreams.propTypes = {
@@ -29,9 +30,13 @@ OTStreams.propTypes = {
     subscribe: PropTypes.func,
   }),
   streams: PropTypes.arrayOf(PropTypes.object),
+  subContainerStyles: PropTypes.arrayOf(PropTypes.object),
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 OTStreams.defaultProps = {
   session: null,
   streams: [],
+  subContainerStyles: [],
+  style: {},
 };

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -29,6 +29,13 @@ export default class OTSubscriber extends Component {
     updateSubscriberProperty('subscribeToAudio');
     updateSubscriberProperty('subscribeToVideo');
 
+    // manage height and width properties evolution
+    if (this.props.containerStyle.width && this.props.containerStyle.height) {
+      const container = document.getElementById(this.containerId);
+      container.style.width = this.props.containerStyle.width;
+      container.style.height = this.props.containerStyle.height;
+    }
+
     if (this.props.session !== prevProps.session || this.props.stream !== prevProps.stream) {
       this.destroySubscriber(prevProps.session);
       this.createSubscriber();
@@ -49,8 +56,11 @@ export default class OTSubscriber extends Component {
       return;
     }
 
+    this.containerId = uuid();
+    const { containerId } = this;
     const container = document.createElement('div');
     container.setAttribute('class', 'OTSubscriberContainer');
+    container.setAttribute('id', containerId);
     this.node.appendChild(container);
 
     this.subscriberId = uuid();
@@ -67,9 +77,9 @@ export default class OTSubscriber extends Component {
           return;
         }
         if (err && typeof this.props.onError === 'function') {
-          this.props.onError(err);
+          this.props.onError(err, this.props.stream);
         } else if (!err && typeof this.props.onSubscribe === 'function') {
-          this.props.onSubscribe();
+          this.props.onSubscribe(this.props.stream);
         }
       },
     );
@@ -117,6 +127,7 @@ OTSubscriber.propTypes = {
     unsubscribe: PropTypes.func,
   }),
   properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  containerStyle: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   eventHandlers: PropTypes.objectOf(PropTypes.func),
   onSubscribe: PropTypes.func,
   onError: PropTypes.func,
@@ -126,6 +137,7 @@ OTSubscriber.defaultProps = {
   stream: null,
   session: null,
   properties: {},
+  containerStyle: {},
   eventHandlers: null,
   onSubscribe: null,
   onError: null,


### PR DESCRIPTION
I needed some styling capabilities so I forked and modified the OTPublisher, OTStreams, OTsubscriber to:
 - allow video container size modifications
 - pass the created stream to onPublish and onSuscribe event
 - pass the err to onError event

I opened the corresponding issue #29.


